### PR TITLE
Fix for OUJS

### DIFF
--- a/BaiduPanDownloadHelper.user.js
+++ b/BaiduPanDownloadHelper.user.js
@@ -16,7 +16,7 @@
 // @require        https://greasyfork.org/scripts/2599/code/gm2_port_v102.js
 
 
-// @license        GPL version 3
+// @license        GPL-3.0
 // @include        http*://yun.baidu.com/share/*
 // @include        http*://pan.baidu.com/share/*
 // @include        http*://yun.baidu.com/s/*


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify all of your affected scripts.

You also have a bunch of other scripts but not here on GH with `MIT` and `BSD`. The SPDX code for `MIT` is `MIT`. BSD is a bit trickier... see a similar issue I opened over [here](https://openuserjs.org/scripts/jscher2000/Google_Hit_Hider_by_Domain_%28Search_Filter_Block_Sites%29/issues/%60license%60_paradox) with another Author.

Until this change is made you will be unable to update those affected scripts.

Thanks,
OUJS Staff